### PR TITLE
Added .uninett-padded-small class

### DIFF
--- a/uninett-theme/css/uninett.css
+++ b/uninett-theme/css/uninett.css
@@ -333,7 +333,9 @@ input[type="search"] {
 
 .uninett-padded {
 	padding: 40px;
-	
+}
+.uninett-padded-small {
+	padding: 20px 10px;
 }
 
 .uninett-whole-row {


### PR DESCRIPTION
I use this in the new eduroam.no design, as `40px` is too much empty space for the buttons.
