### PR TITLE
Patch 1

### DIFF
--- a/css/uninett.css
+++ b/css/uninett.css
@@ -5,7 +5,7 @@
 	     url('../fonts/colfaxThin.woff') format('woff'),
 	     url('../fonts/colfaxThin.ttf') format('truetype'),
 	     url('../fonts/colfaxThin.svg#webfont') format('svg');
-} 
+}
 
 @font-face{
 	font-family: 'colfaxLight';
@@ -155,7 +155,6 @@ input[type="search"] {
 .navbar {
 	min-height: 70px;
 	border: 0px;
-
 }
 
 .navbar-default {

--- a/css/uninett.css
+++ b/css/uninett.css
@@ -1,4 +1,4 @@
-@font-face{ 
+@font-face{
 	font-family: 'colfaxThin';
 	src: url('../fonts/colfaxThin.eot');
 	src: url('../fonts/colfaxThin.eot?#iefix') format('embedded-opentype'),
@@ -7,7 +7,7 @@
 	     url('../fonts/colfaxThin.svg#webfont') format('svg');
 }
 
-@font-face{ 
+@font-face{
 	font-family: 'colfaxLight';
 	src: url('../fonts/colfaxLight.eot');
 	src: url('../fonts/colfaxLight.eot?#iefix') format('embedded-opentype'),
@@ -16,7 +16,7 @@
 	     url('../fonts/colfaxLight.svg#webfont') format('svg');
 }
 
-@font-face{ 
+@font-face{
 	font-family: 'colfaxRegular';
 	src: url('../fonts/colfaxRegular.eot');
 	src: url('../fonts/colfaxRegular.eot?#iefix') format('embedded-opentype'),
@@ -25,7 +25,7 @@
 	     url('../fonts/colfaxRegular.svg#webfont') format('svg');
 }
 
-@font-face{ 
+@font-face{
 	font-family: 'colfaxRegularItalic';
 	src: url('../fonts/colfaxRegularItalic.eot');
 	src: url('../fonts/colfaxRegularItalic.eot?#iefix') format('embedded-opentype'),
@@ -34,7 +34,7 @@
 	     url('../fonts/colfaxRegularItalic.svg#webfont') format('svg');
 }
 
-@font-face{ 
+@font-face{
 	font-family: 'colfaxMedium';
 	src: url('../fonts/colfaxMedium.eot');
 	src: url('../fonts/colfaxMedium.eot?#iefix') format('embedded-opentype'),
@@ -43,7 +43,7 @@
 	     url('../fonts/colfaxMedium.svg#webfont') format('svg');
 }
 
-@font-face{ 
+@font-face{
 	font-family: 'colfaxBold';
 	src: url('../fonts/colfaxBold.eot');
 	src: url('../fonts/colfaxBold.eot?#iefix') format('embedded-opentype'),
@@ -52,15 +52,21 @@
 	     url('../fonts/colfaxBold.svg#webfont') format('svg');
 }
 
+html {
+	overflow-y: scroll;
+}
 
 body {
 	background-color:#eeebe8;
 	font-family: 'colfaxRegular', Arial, sans-serif;
 	font-size: 16px;
 	line-height: 1.6;
-	padding-top: 70px;
+	/* padding-top: 70px; */
 }
 
+.navbar-site {
+	padding-top: 70px;
+}
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 	font-family: "colfaxMedium", Helvetica, Arial, sans-serif;
@@ -71,7 +77,7 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 
 h1, h2, h3 {
 	margin-top: 0px;
-	
+
 }
 
 h1, .h1 {
@@ -87,31 +93,31 @@ h2, .h2 {
 	margin-bottom: 20px;
 	font-size: 24px;
 	font-weight: Normal;
-	font-family: 'colfaxRegularItalic', Helvetica, Arial, sans-serif; 
+	font-family: 'colfaxRegularItalic', Helvetica, Arial, sans-serif;
 	line-height: 1.5;
 }
 
 .uninett-author {
-	font-family: 'colfaxRegular', Helvetica, Arial, sans-serif; 
+	font-family: 'colfaxRegular', Helvetica, Arial, sans-serif;
 	font-size: 12px;
 	color: #999;
 	margin-top: 16px;
 	margin-bottom: 16px;
-	
+
 }
 
 .uninett-author-results {
-	font-family: 'colfaxRegular', Helvetica, Arial, sans-serif; 
+	font-family: 'colfaxRegular', Helvetica, Arial, sans-serif;
 	font-size: 12px;
 	color: #999;
 	margin-top: 10px;
 	margin-bottom: 10px;
-	
+
 }
 
 a {
 	color: #005c9e;
-	
+
 }
 
 a:hover, a:focus {
@@ -128,55 +134,55 @@ i, em {
 	font-weight: normal;
 }
 
-.form-control {
+.form-control:not(select) {
 	-webkit-appearance: none;
 	border-radius: 4;
 	-webkit-border-radius: 4px;
 }
 
 input[type="search"] {
-	-webkit-appearance: none; 
+	-webkit-appearance: none;
 	border-radius: 3px;
 
 }
 
 .navbar-fixed-top {
 	border-width: 0 0 0px;
-	
-	
+
+
 }
 
 .navbar {
 	min-height: 70px;
 	border: 0px;
-	
+
 }
 
 .navbar-default {
 	background-color: #fff;
 	border-color: #fff;
-	
+
 }
 
 
-.navbar-brand {		
+.navbar-brand {
 		padding: 16px 14px;
-		
-		
+
+
 }
 
 
 .navbar-nav {
-	
+
 	margin-top: 17px;
 	float: none;
-	
+
 }
 
 
 
 .navbar-nav > li > a {
-	
+
 	font-family: 'colfaxRegular', Arial, sans-serif;
 	font-size: 15px;
 	color: #666464;
@@ -184,13 +190,13 @@ input[type="search"] {
 	padding-right: 25px;
 	padding-top: 13px;
 	padding-bottom: 9px;
-	
+
 }
 
 .navbar-nav .uninett-search {
 	float:right;
-	
-	
+
+
 }
 
 .navbar-nav .uninett-login {
@@ -200,13 +206,13 @@ input[type="search"] {
 
 .navbar-header:after {
 	clear: none !important;
-	
+
 }
 
 .uninett-menu-search {
-	
+
 	margin-top: 6px;
-	
+
 }
 
 .navbar-form-uninett {
@@ -235,13 +241,13 @@ input[type="search"] {
 .navbar-default .navbar-nav > .active > a, .navbar-default .navbar-nav > .active > a:hover, .navbar-default .navbar-nav > .active > a:focus {
 	background-color: #fff;
 	color: #eb212e;
-	
-	
+
+
 }
 
 .navbar-toggle {
 	border: 0px solid transparent;
-	border-radius: 0px;	
+	border-radius: 0px;
 	margin-right: 6px;
 }
 
@@ -256,14 +262,14 @@ input[type="search"] {
 }
 
 .department {
-	
+
 	font-family: 'colfaxLight', Arial, sans-serif;
 	font-size: 26px;
 	color: #6a5f58;
 	float: left;
 	padding-right: 25px;
 	padding-top: 16px;
-	
+
 }
 
 
@@ -281,7 +287,7 @@ input[type="search"] {
 	border: 0px solid #cccccc;
 	border: 1px solid rgba(0, 0, 0, 0);
 	border-radius: 0px;
-	
+
 }
 
 .dropdown-menu > li > a:hover, .dropdown-menu > li > a:focus {
@@ -307,7 +313,7 @@ input[type="search"] {
 .jumbotron {
 	margin-bottom: 0px;
 	margin-top: 20px;
-	background-color: #92ceef;
+	background-color: #70bbea;
 }
 
 .jumbotron h1 {
@@ -342,13 +348,13 @@ input[type="search"] {
 	margin-left: 0px;
 	margin-right: 0px;
 	margin-top: 20px;
-	
+
 }
 
 .uninett-whole-row-col {
 	padding-left: 0px;
 	padding-right: 0px;
-	
+
 }
 
 .gutter {
@@ -356,7 +362,7 @@ input[type="search"] {
 }
 
 .uninett-color-lightBlue {
-	background-color: #92ceef;
+	background-color: #70bbea;
 }
 
 .uninett-color-blue {
@@ -414,7 +420,7 @@ input[type="search"] {
 
 .uninett-pattern1 {
 	background-image:url(../images/uninett_struktur1.jpg);
-	
+
 }
 
 
@@ -428,14 +434,14 @@ input[type="search"] {
 	color: #231f20;
 	background-color: #f2f2f2;
 	border-color: #f2f2f2;
-	
+
 }
 
 .btn-default:hover, .btn-default:focus, .btn-default:active, .btn-default.active, .open .dropdown-toggle.btn-default {
 	color: #231f20;
 	background-color: #dfdfdf;
 	border-color: #dfdfdf;
-	
+
 }
 
 
@@ -445,14 +451,14 @@ input[type="search"] {
 	color: #ffffff;
 	background-color: #337db1;
 	border-color: #337db1;
-	
+
 }
 
 .btn-primary:hover, .btn-primary:focus, .btn-primary:active, .btn-primary.active, .open .dropdown-toggle.btn-primary {
 	color: #ffffff;
 	background-color: #005c9e;
 	border-color: #005c9e;
-	
+
 }
 
 
@@ -463,14 +469,14 @@ input[type="search"] {
 	color: #ffffff;
 	background-color: #33c09e;
 	border-color: #33c09e;
-	
+
 }
 
 .btn-success:hover, .btn-success:focus, .btn-success:active, .btn-success.active, .open .dropdown-toggle.btn-success {
 	color: #ffffff;
 	background-color: #00b086;
 	border-color: #00b086;
-	
+
 }
 
 
@@ -480,14 +486,14 @@ input[type="search"] {
 	color: #ffffff;
 	background-color: #8fc1dd;
 	border-color: #8fc1dd;
-	
+
 }
 
 .btn-info:hover, .btn-info:focus, .btn-info:active, .btn-info.active, .open .dropdown-toggle.btn-info {
 	color: #ffffff;
 	background-color: #73b1d4;
 	border-color: #73b1d4;
-	
+
 }
 
 
@@ -497,14 +503,14 @@ input[type="search"] {
 	color: #ffffff;
 	background-color: #f59b65;
 	border-color: #f59b65;
-	
+
 }
 
 .btn-warning:hover, .btn-warning:focus, .btn-warning:active, .btn-warning.active, .open .dropdown-toggle.btn-warning {
 	color: #ffffff;
 	background-color: #f3823e;
 	border-color: #f3823e;
-	
+
 }
 
 
@@ -514,17 +520,28 @@ input[type="search"] {
 	color: #ffffff;
 	background-color: #ef4d58;
 	border-color: #ef4d58;
-	
+
 }
 
 .btn-danger:hover, .btn-danger:focus, .btn-danger:active, .btn-danger.active, .open .dropdown-toggle.btn-danger {
 	color: #ffffff;
 	background-color: #eb212e;
 	border-color: #eb212e;
-	
+
 }
 
+.btn[disabled], .btn[disabled]:hover, button[disabled], button[disabled]:hover{
+	cursor:default;
+	background-color: lightgrey;
+  border-color: lightgrey;
+  color: grey;
+	opacity: 1;
+}
 
+button.glyphicon_search_menu{
+	border:none;
+	background:none;
+}
 
 .btn-group>.btn, .btn-group-vertical>.btn {
 	margin-right: 3px;
@@ -539,7 +556,8 @@ input[type="search"] {
 
 .glyphicon_search_menu {
 	top: 14px;
-	margin-left: -27px;
+	margin-left: -33px;
+	margin-top: -2px;
 	font-size: 18px;
 }
 
@@ -552,13 +570,13 @@ input[type="search"] {
 	padding: 4px 11px;
 	margin-bottom: 16px;
 	background-color: #f5f5f5;
-	
-	
+
+
 }
 
 
 .pagination>.active>a, .pagination>.active>span, .pagination>.active>a:hover, .pagination>.active>span:hover, .pagination>.active>a:focus, .pagination>.active>span:focus {
-	
+
 	background-color: #337db1;
 	border-color: #337db1;
 
@@ -577,9 +595,12 @@ input[type="search"] {
 
 
 .alert-success {
-	background-color: #e5f7f3;
+	/*background-color: #e5f7f3;
 	border-color: #e5f7f3;
-	color: #00b086;
+	color: #00b086;*/
+	background-color: #d7fff6;
+	border-color: #d7fff6;
+	color: #008263;
 }
 
 .alert-info {
@@ -659,7 +680,7 @@ input[type="search"] {
 	float: right;
 	right: 50%;
 	position: relative;
-	
+
 }
 
 .footer-content-uninett {
@@ -672,14 +693,14 @@ input[type="search"] {
 .footer-logo {
 	float:left;
 	padding: 5px;
-	
+
 }
 
 
 .footer-logo img {
 	width: 0.9em;
 	height: 1.2em;
-	
+
 }
 
 .footer-uninett-department {
@@ -687,7 +708,7 @@ input[type="search"] {
 	margin-top: 7px;
 	font-family: 'colfaxMedium';
 	color: #333;
-	
+
 }
 
 
@@ -698,11 +719,20 @@ input[type="search"] {
 	margin: 0px;
 }
 
+.uninett-ul li {
+	background-image: url(../images/li.png);
+	background-repeat: no-repeat;
+	background-position: 0px 8px;
+	padding-left: 14px;
+	line-height: 30px;
+	list-style:none;
+}
+
 .uninett-ul-li {
 	background-image: url(../images/li.png);
 	background-repeat: no-repeat;
-	background-position: 0px 8px; 
-	padding-left: 14px; 
+	background-position: 0px 8px;
+	padding-left: 14px;
 	line-height: 30px;
 }
 
@@ -733,7 +763,7 @@ input[type="search"] {
 	border-bottom: 0px solid #fff;
 }
 
-dt { 
+dt {
 	font-family: "colfaxMedium", Helvetica, Arial, sans-serif;
 	font-weight: normal;
 }
@@ -746,20 +776,20 @@ dt {
 	.navbar > .container .navbar-brand {
 		margin-left: -14px;
 	}
-  
-	
-  
+
+
+
 }
 
 @media (max-width: 990px) and (min-width: 768px) {
-	
+
 	.navbar-nav {
-	
+
 		margin-top: 16px;
-	
+
 	}
-	
-	
+
+
 	.uninett-login-btn {
 		margin-right: 0px;
 		margin-left: 16px;
@@ -768,227 +798,227 @@ dt {
 	.navbar > .container .navbar-brand {
 		margin-left: -13px;
 	}
-	
+
 	.container > .navbar-header, .container > .navbar-collapse {
 		margin-top: 2px;
 	}
-	
+
 	.jumbotron h1 {
 		font-size: 50px;
 		font-family: 'colfaxLight', Arial, sans-serif;
 	}
-	
-	.navbar-brand {		
+
+	.navbar-brand {
 		padding: 16px 12px;
 		width: 140px;
-		
+
 	}
-	
-	
+
+
 	.navbar-toggle {
 		margin-top: 15px;
 	}
-	
+
 	.navbar img {
 		max-width: 100%;
-	
+
 	}
 
-		
+
 	.navbar-nav > li > a {
-		
+
 		font-family: 'colfaxRegular', Arial, sans-serif;
 		font-size: 14px;
 		padding-left: 15px;
 		padding-right: 15px;
 		padding-top: 10px;
 		padding-bottom: 9px;
-		
+
 	}
-	
+
 	.navbar-nav .uninett-search {
 		float:none;
 		height: 60px;
-		
+
 	}
-	
+
 	.uninett-menu-search {
 		margin-left: 13px;
 		margin-top: 6px;
 	}
-	
+
 	.glyphicon_search_menu {
 		top: 12px;
 		margin-left: -24px;
 		font-size: 16px;
 	}
-	
+
 	.department {
-		
+
 		font-family: 'colfaxRegular', Arial, sans-serif;
 		font-size: 22px;
 		float: left;
 		padding-right: 20px;
 		padding-top: 15px;
-		
+
 	}
 
-	
-	
-	
+
+
+
 }
 
 
 @media (max-width: 767px) {
-	
+
 	body {
 		padding-top: 46px;
 		font-family: 'colfaxLight', Arial, sans-serif;
 		font-size: 14px;
-		line-height: 1.4;	
-	
-	}	
+		line-height: 1.4;
+
+	}
 
 	.navbar {
 		min-height: 50px;
-	
-		
-	}
-	
-	.navbar-nav {
-		margin-bottom: 30px;
-		
+
+
 	}
 
-	
+	.navbar-nav {
+		margin-bottom: 30px;
+
+	}
+
+
 	.navbar img {
 		max-width: 100%;
-	
+
 	}
-	
-	
-	.navbar-brand {		
+
+
+	.navbar-brand {
 		padding: 12px 10px;
 		width: 110px;
-		
+
 	}
-	
-	
+
+
 	.navbar-nav .uninett-search {
 		float:none;
 		height: 60px;
 	}
-	
-	
+
+
 	.department {
 		font-family: 'colfaxLight', Arial, sans-serif;
 		font-size: 18px;
 		float: left;
 		padding-right: 0px;
 		padding-top: 13px;
-		
+
 	}
-	
+
 	.navbar-default .navbar-nav .open .dropdown-menu>.active>a, .navbar-default .navbar-nav .open .dropdown-menu>.active>a:hover, .navbar-default .navbar-nav .open .dropdown-menu>.active>a:focus {
 		background-color: #eb212e;
 		color: #fff;
 	}
 
-	
+
 	.container > .navbar-header, .container > .navbar-collapse {
 		margin-left: -10px;
-		
+
 	}
-	
+
 	.jumbotron {
 		margin-top: 18px;
-		
+
 	}
-	
+
 	.jumbotron h1 {
 		font-size: 40px;
 		font-family: 'colfaxLight', Arial, sans-serif;
 	}
-	
+
 	.jumbotron p {
 		line-height: 1.3;
 		font-size: 16px;
-		
+
 	}
-	
+
 	h1 {
 		margin-top: 1px;
 	}
-	
+
 	.btn-lg {
 		padding: 10px 16px;
 		font-size: 14px;
 		border-radius: 4px;
 	}
-	
-	
+
+
 	h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 		font-family: "colfaxBold", Helvetica, Arial, sans-serif;
-	
+
 	}
-	
+
 	h1, .h1 {
 		font-size: 36px;
 	}
-	
+
 	h2, .h2 {
 		font-size: 24px;
 	}
-	
+
 	.gutter {
 		margin-top: 15px;
 	}
-	
+
 	.uninett-padded {
 		padding: 20px;
-		
+
 	}
-	
+
 	.uninett-hr-divider {
 		border-top: 1px solid #d9d6d4;
 		margin: 30px 0;
 	}
-	
+
 
 	.lead {
 		font-size: 18px;
 		line-height: 1.4;
 	}
-	
+
 	.uninett-author {
 		font-size: 10px;
 		color: #999;
 		margin-top: 16px;
 		margin-bottom: 16px;
-		
+
 	}
-	
+
 	.uninett-author-results {
-		
+
 		font-size: 10px;
 		margin-top: 10px;
 		margin-bottom: 10px;
-		
+
 	}
-	
+
 	.uninett-menu-search {
 		margin-left: 20px;
 		width: 50%;
-		
+
 	}
-	
+
 	.glyphicon_search_menu {
 		top: 13px;
 		margin-left: -29px;
 		font-size: 18px;
 	}
-	
-	
+
+
 	.uninett-login-btn {
 		margin-right: 20px;
 		margin-left: 20px;
@@ -997,21 +1027,25 @@ dt {
 
 }
 
-
+:target:before {
+	content:"";
+	display:block;
+	height:70px;
+	margin-top:-70px;
+}
 
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5),
 only screen and (min--moz-device-pixel-ratio: 1.5),
 only screen and (min-resolution: 240dpi) {
-	
+
 	.uninett-ul {
 		padding: 10px 0px 0px 10px;
 	}
-	
+
 	.uninett-ul-li {
 		background-image: url(../images/li@2x.png);
 		line-height: 26px;
 		background-size: 8px;
 	}
-	
-}
 
+}

--- a/css/uninett.css
+++ b/css/uninett.css
@@ -1026,12 +1026,6 @@ dt {
 
 }
 
-:target:before {
-	content:"";
-	display:block;
-	height:70px;
-	margin-top:-70px;
-}
 
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5),
 only screen and (min--moz-device-pixel-ratio: 1.5),

--- a/css/uninett.css
+++ b/css/uninett.css
@@ -5,7 +5,7 @@
 	     url('../fonts/colfaxThin.woff') format('woff'),
 	     url('../fonts/colfaxThin.ttf') format('truetype'),
 	     url('../fonts/colfaxThin.svg#webfont') format('svg');
-}
+} 
 
 @font-face{
 	font-family: 'colfaxLight';

--- a/js/uninett-bootstrap.js
+++ b/js/uninett-bootstrap.js
@@ -1,0 +1,34 @@
+/**
+ * Check a href for an anchor. If exists, and in document, scroll to it.
+ * If href argument ommited, assumes context (this) is HTML Element,
+ * which will be the case when invoked by jQuery after an event
+ */
+function scroll_if_anchor(href) {
+    href = typeof(href) == "string" ? href : $(this).attr("href");
+
+    // You could easily calculate this dynamically if you prefer
+    var fromTop = $(".navbar").height() + 50;
+
+    // If our Href points to a valid, non-empty anchor, and is on the same page (e.g. #foo)
+    // Legacy jQuery and IE7 may have issues: http://stackoverflow.com/q/1593174
+    if(href.indexOf("#") == 0) {
+        var $target = $(href);
+
+        // Older browser without pushState might flicker here, as they momentarily
+        // jump to the wrong position (IE < 10)
+        if($target.length) {
+            $('html, body').animate({ scrollTop: $target.offset().top - fromTop });
+            if(history && "pushState" in history) {
+                history.pushState({}, document.title, window.location.pathname + href);
+                return false;
+            }
+        }
+    }
+}
+
+// When our page loads, check to see if it contains and anchor
+scroll_if_anchor(window.location.hash);
+
+// Intercept all anchor clicks
+
+$("body").on("click", "a", scroll_if_anchor);


### PR DESCRIPTION
2 - Added uninett-ul li for simpler use of custom bulletlist
4 - Added class navbar-site. Is to be used on body when there is a navbar on the site
5 - Always showing scrollbar
7 - Increased contrast in header to #70bbea
8 - Added :not(select) to form-control class, to leave out select
9 - Added styles for disabled buttons. Both buttons, and the class btn
10 - Added styles to the glyphicon_search_menu so that the "button" works with a button element, rather than a span. This makes it clickable. gh_pages has to be changed accordingly.
17 - Changed colors on alert-success. New colors are bg-color and border-color: #d7fff6 and color #008263
18 - Added :target:before and padding-top:70px, margin-top:-70px to make up for the navbar-site. Still some problems with this, and that it might make some elements unclickable.
